### PR TITLE
feat: Add title attribute to script tag for better accessibility

### DIFF
--- a/src/AnnounceKit.vue
+++ b/src/AnnounceKit.vue
@@ -208,6 +208,7 @@ export default {
         var scripttag = document.createElement("script");
         scripttag["async"] = true;
         scripttag["src"] = `https://cdn.announcekit.app/widget-v2.js`;
+        scripttag.setAttribute("aria-label", "iframe");
 
         var scr = document.getElementsByTagName("script")[0];
         scr.parentNode.insertBefore(scripttag, scr);

--- a/src/AnnounceKit.vue
+++ b/src/AnnounceKit.vue
@@ -208,7 +208,7 @@ export default {
         var scripttag = document.createElement("script");
         scripttag["async"] = true;
         scripttag["src"] = `https://cdn.announcekit.app/widget-v2.js`;
-        scripttag.setAttribute("aria-label", "iframe");
+        scripttag.setAttribute("title", "Announcekit widget");
 
         var scr = document.getElementsByTagName("script")[0];
         scr.parentNode.insertBefore(scripttag, scr);


### PR DESCRIPTION
For accessibility reasons, [an iframe should have a title or an aria-label attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label). This PR adds a `title` attribute.

We use announcekit on our product and right now the accessibility standards requested by our enterprise customers are not being met. The fix is simple, though, and this would benefit us immensely. 

Hope this can be reviewed and merged as is, but let me know if there's anything I might need to include here.

@namirali @mcucen 